### PR TITLE
Fix compiling on ARM-based platforms

### DIFF
--- a/alpm/src/signing.rs
+++ b/alpm/src/signing.rs
@@ -86,7 +86,7 @@ impl PgpKey {
     }
 
     pub fn pubkey_algo(&self) -> i8 {
-        self.inner.pubkey_algo
+        self.inner.pubkey_algo as i8
     }
 }
 
@@ -190,7 +190,7 @@ impl Alpm {
             )
         };
 
-        self.check_ret(ret)?;;
+        self.check_ret(ret)?;
         Ok(AlpmList::new(self, keys, FreeMethod::FreeInner))
     }
 }


### PR DESCRIPTION
On several ARM- and PowerPC-based platforms, [`c_char` is defined as `u8`](https://doc.rust-lang.org/src/std/os/raw/mod.rs.html#12), which, without casting, prevents compiling on these platforms.