### PR TITLE
Fix types for ARMv7 arch

### DIFF
--- a/alpm/src/conflict.rs
+++ b/alpm/src/conflict.rs
@@ -23,11 +23,11 @@ impl Drop for Conflict {
 
 impl Conflict {
     pub fn package1_hash(&self) -> u64 {
-        unsafe { (*self.inner).package1_hash }
+        unsafe { (*self.inner).package1_hash.into() }
     }
 
     pub fn package2_hash(&self) -> u64 {
-        unsafe { (*self.inner).package2_hash }
+        unsafe { (*self.inner).package2_hash.into() }
     }
 
     pub fn package1(&self) -> &str {

--- a/alpm/src/filelist.rs
+++ b/alpm/src/filelist.rs
@@ -17,7 +17,7 @@ impl File {
     }
 
     pub fn size(&self) -> i64 {
-        self.inner.size
+        self.inner.size.into()
     }
 
     pub fn mode(&self) -> u32 {

--- a/alpm/src/signing.rs
+++ b/alpm/src/signing.rs
@@ -85,8 +85,8 @@ impl PgpKey {
         self.inner.revoked
     }
 
-    pub fn pubkey_algo(&self) -> i8 {
-        self.inner.pubkey_algo as i8
+    pub fn pubkey_algo(&self) -> u8 {
+        self.inner.pubkey_algo as u8
     }
 }
 


### PR DESCRIPTION
**alpm.rs** cannot compile on ARMv7, because on this architecture:
- c_ulong is u32
- c_long is i32
- c_char is u8
