### PR TITLE
No more unnecessary string copies

### DIFF
--- a/alpm-utils/src/alpm.rs
+++ b/alpm-utils/src/alpm.rs
@@ -3,13 +3,13 @@ use crate::depends::satisfies_ver;
 use alpm::{Alpm, Result, Package, Depend};
 
 pub trait AlpmExt {
-    fn find_local_satisfier<S: Into<String>>(&self, pkg: S) -> Result<Option<Package>>;
+    fn find_local_satisfier(&self, pkg: impl AsRef<str>) -> Result<Option<Package>>;
 }
 
 impl AlpmExt for Alpm {
-    fn find_local_satisfier<S: Into<String>>(&self, pkg: S) -> Result<Option<Package>> {
+    fn find_local_satisfier(&self, pkg: impl AsRef<str>) -> Result<Option<Package>> {
         let localdb = self.localdb();
-        let pkg = pkg.into();
+        let pkg = pkg.as_ref();
 
         if let Ok(alpm_pkg) = localdb.pkg(&pkg) {
             if satisfies_ver(&Depend::new(&pkg), alpm_pkg.version()) {

--- a/alpm-utils/src/depends.rs
+++ b/alpm-utils/src/depends.rs
@@ -13,7 +13,7 @@ pub fn satisfies_dep<'a, S: AsRef<str>, V: AsRef<Ver>>(dep: &Depend, name: S, ve
     satisfies_ver(dep, version)
 }
 
-/// Checks if a dependency is satisdied by a provide.
+/// Checks if a dependency is satisfied by a provide.
 pub fn satisfies_provide<'a>(dep: &Depend<'a>, provide: &Depend<'a>) -> bool {
     if dep.name() != provide.name() {
         return false;
@@ -23,7 +23,10 @@ pub fn satisfies_provide<'a>(dep: &Depend<'a>, provide: &Depend<'a>) -> bool {
         return false;
     }
 
-    satisfies_ver(dep, provide.version())
+    match provide.version() {
+        None => false,
+        Some(provide_ver) => satisfies_ver(dep, provide_ver)
+    }
 }
 
 /// Checks if a Depend is satisfied by a name + version + provides combo
@@ -62,15 +65,20 @@ fn satisfies_ver<'a, V: AsRef<Ver>>(dep: &Depend<'a>, version: V) -> bool {
         return true;
     }
 
-    let cmp = version.cmp(dep.version());
+    match dep.version() {
+        None => false,
+        Some(depver) => {
+            let cmp = version.cmp(depver);
 
-    match dep.depmod() {
-        DepMod::Eq => cmp == Ordering::Equal,
-        DepMod::Ge => cmp == Ordering::Greater || cmp == Ordering::Equal,
-        DepMod::Le => cmp == Ordering::Less || cmp == Ordering::Equal,
-        DepMod::Gt => cmp == Ordering::Greater,
-        DepMod::Lt => cmp == Ordering::Less,
-        DepMod::Any => true,
+            match dep.depmod() {
+                DepMod::Eq => cmp == Ordering::Equal,
+                DepMod::Ge => cmp == Ordering::Greater || cmp == Ordering::Equal,
+                DepMod::Le => cmp == Ordering::Less || cmp == Ordering::Equal,
+                DepMod::Gt => cmp == Ordering::Greater,
+                DepMod::Lt => cmp == Ordering::Less,
+                DepMod::Any => true,
+            }
+        }
     }
 }
 

--- a/alpm/src/alpm.rs
+++ b/alpm/src/alpm.rs
@@ -37,10 +37,10 @@ impl Drop for Alpm {
 }
 
 impl Alpm {
-    pub fn new<S: Into<String>>(root: S, db_path: S) -> Result<Alpm> {
+    pub fn new(root: impl AsRef<str>, db_path: impl AsRef<str>) -> Result<Alpm> {
         let mut err = alpm_errno_t::ALPM_ERR_OK;
-        let root = CString::new(root.into()).unwrap();
-        let db_path = CString::new(db_path.into()).unwrap();
+        let root = CString::new(root.as_ref()).unwrap();
+        let db_path = CString::new(db_path.as_ref()).unwrap();
 
         let handle = unsafe { alpm_initialize(root.as_ptr(), db_path.as_ptr(), &mut err) };
 

--- a/alpm/src/be_pkg.rs
+++ b/alpm/src/be_pkg.rs
@@ -31,13 +31,13 @@ impl<'a> LoadedPackage<'a> {
 }
 
 impl Alpm {
-    pub fn pkg_load<'a, S: Into<String>>(
+    pub fn pkg_load<'a>(
         &'a self,
-        filename: S,
+        filename: impl AsRef<str>,
         full: bool,
         level: SigLevel,
     ) -> Result<LoadedPackage<'a>> {
-        let filename = CString::new(filename.into()).unwrap();
+        let filename = CString::new(filename.as_ref()).unwrap();
         let mut pkg = Pkg {
             pkg: ptr::null_mut(),
             handle: self,

--- a/alpm/src/db.rs
+++ b/alpm/src/db.rs
@@ -38,8 +38,8 @@ pub struct DbBuilder {
 }
 
 impl Alpm {
-    pub fn register_syncdb<S: Into<String>>(&self, name: S, sig_level: SigLevel) -> Result<Db> {
-        let name = CString::new(name.into()).unwrap();
+    pub fn register_syncdb(&self, name: impl AsRef<str>, sig_level: SigLevel) -> Result<Db> {
+        let name = CString::new(name.as_ref()).unwrap();
 
         let db =
             unsafe { alpm_register_syncdb(self.handle, name.as_ptr(), sig_level.bits() as i32) };
@@ -48,12 +48,12 @@ impl Alpm {
         Ok(Db { db, handle: self })
     }
 
-    pub fn register_syncdb_mut<S: Into<String>>(
+    pub fn register_syncdb_mut(
         &mut self,
-        name: S,
+        name: impl AsRef<str>,
         sig_level: SigLevel,
     ) -> Result<DbMut> {
-        let name = CString::new(name.into()).unwrap();
+        let name = CString::new(name.as_ref()).unwrap();
 
         let db =
             unsafe { alpm_register_syncdb(self.handle, name.as_ptr(), sig_level.bits() as i32) };
@@ -74,20 +74,20 @@ impl<'a> DbMut<'a> {
         unsafe { alpm_db_unregister(self.db) };
     }
 
-    pub fn add_server<S: Into<String>>(&self, server: S) -> Result<()> {
-        let server = CString::new(server.into()).unwrap();
+    pub fn add_server(&self, server: impl AsRef<str>) -> Result<()> {
+        let server = CString::new(server.as_ref()).unwrap();
         let ret = unsafe { alpm_db_add_server(self.db, server.as_ptr()) };
         self.handle.check_ret(ret)
     }
 
-    pub fn set_servers<S: Into<String>, I: IntoIterator<Item = S>>(&self, list: I) -> Result<()> {
+    pub fn set_servers<S: AsRef<str>, I: IntoIterator<Item = S>>(&self, list: I) -> Result<()> {
         let list = to_strlist(list);
         let ret = unsafe { alpm_db_set_servers(self.db, list) };
         self.handle.check_ret(ret)
     }
 
-    pub fn remove_server<S: Into<String>>(&self, server: S) -> Result<()> {
-        let server = CString::new(server.into()).unwrap();
+    pub fn remove_server(&self, server: impl AsRef<str>) -> Result<()> {
+        let server = CString::new(server.as_ref()).unwrap();
         let ret = unsafe { alpm_db_remove_server(self.db, server.as_ptr()) };
         self.handle.check_ret(ret)
     }
@@ -104,8 +104,8 @@ impl<'a> Db<'a> {
         AlpmList::new(self.handle, list, FreeMethod::None)
     }
 
-    pub fn pkg<S: Into<String>>(&self, name: S) -> Result<Package<'a>> {
-        let name = CString::new(name.into()).unwrap();
+    pub fn pkg(&self, name: impl AsRef<str>) -> Result<Package<'a>> {
+        let name = CString::new(name.as_ref()).unwrap();
         let pkg = unsafe { alpm_db_get_pkg(self.db, name.as_ptr()) };
         self.handle.check_null(pkg)?;
         unsafe { Ok(Package::new(self.handle, pkg)) }
@@ -117,8 +117,8 @@ impl<'a> Db<'a> {
         Ok(AlpmList::new(self.handle, pkgs, FreeMethod::None))
     }
 
-    pub fn group<S: Into<String>>(&self, name: S) -> Result<Group> {
-        let name = CString::new(name.into()).unwrap();
+    pub fn group(&self, name: impl AsRef<str>) -> Result<Group> {
+        let name = CString::new(name.as_ref()).unwrap();
         let group = unsafe { alpm_db_get_group(self.db, name.as_ptr()) };
         self.handle.check_null(group)?;
         Ok(Group {
@@ -133,7 +133,7 @@ impl<'a> Db<'a> {
     }
 
     #[cfg(not(feature = "git"))]
-    pub fn search<S: Into<String>, I: IntoIterator<Item = S>>(
+    pub fn search<S: AsRef<str>, I: IntoIterator<Item = S>>(
         &self,
         list: I,
     ) -> Result<AlpmList<'a, Package<'a>>> {
@@ -146,7 +146,7 @@ impl<'a> Db<'a> {
     }
 
     #[cfg(feature = "git")]
-    pub fn search<S: Into<String>, I: IntoIterator<Item = S>>(
+    pub fn search<S: AsRef<str>, I: IntoIterator<Item = S>>(
         &self,
         list: I,
     ) -> Result<AlpmList<'a, Package<'a>>> {

--- a/alpm/src/deps.rs
+++ b/alpm/src/deps.rs
@@ -56,15 +56,9 @@ impl<'a> fmt::Display for Depend<'a> {
     }
 }
 
-impl<S: Into<String>> From<S> for Depend<'static> {
-    fn from(s: S) -> Depend<'static> {
-        Depend::new(s)
-    }
-}
-
 impl<'a> Depend<'a> {
-    pub fn new<S: Into<String>>(s: S) -> Depend<'static> {
-        let s = CString::new(s.into()).unwrap();
+    pub fn new(s: impl AsRef<str>) -> Depend<'static> {
+        let s = CString::new(s.as_ref()).unwrap();
         let dep = unsafe { alpm_dep_from_string(s.as_ptr()) };
 
         Depend {
@@ -190,8 +184,8 @@ impl DepMissing {
 }
 
 impl<'a> AlpmList<'a, Db<'a>> {
-    pub fn find_satisfier<S: Into<String>>(&self, dep: S) -> Option<Package<'a>> {
-        let dep = CString::new(dep.into()).unwrap();
+    pub fn find_satisfier(&self, dep: impl AsRef<str>) -> Option<Package<'a>> {
+        let dep = CString::new(dep.as_ref()).unwrap();
 
         let pkg = unsafe { alpm_find_dbs_satisfier(self.handle.handle, self.list, dep.as_ptr()) };
         self.handle.check_null(pkg).ok()?;
@@ -200,8 +194,8 @@ impl<'a> AlpmList<'a, Db<'a>> {
 }
 
 impl<'a> AlpmList<'a, Package<'a>> {
-    pub fn find_satisfier<S: Into<String>>(&self, dep: S) -> Option<Package<'a>> {
-        let dep = CString::new(dep.into()).unwrap();
+    pub fn find_satisfier(&self, dep: impl AsRef<str>) -> Option<Package<'a>> {
+        let dep = CString::new(dep.as_ref()).unwrap();
 
         let pkg = unsafe { alpm_find_satisfier(self.list, dep.as_ptr()) };
         self.handle.check_null(pkg).ok()?;

--- a/alpm/src/dload.rs
+++ b/alpm/src/dload.rs
@@ -6,8 +6,8 @@ use alpm_sys::*;
 use std::ffi::{c_void, CString};
 
 impl Alpm {
-    pub fn fetch_pkgurl<S: Into<String>>(&self, url: S) -> Result<String> {
-        let url = CString::new(url.into()).unwrap();
+    pub fn fetch_pkgurl(&self, url: impl AsRef<str>) -> Result<String> {
+        let url = CString::new(url.as_ref()).unwrap();
         let path = unsafe { alpm_fetch_pkgurl(self.handle, url.as_ptr()) };
         self.check_null(path)?;
         let path_str = unsafe { from_cstr(path) };

--- a/alpm/src/filelist.rs
+++ b/alpm/src/filelist.rs
@@ -36,8 +36,8 @@ impl FileList {
         unsafe { slice::from_raw_parts(self.inner.files as *const File, self.inner.count) }
     }
 
-    pub fn contains<S: Into<String>>(&self, path: S) -> Result<Option<File>> {
-        let path = CString::new(path.into()).unwrap();
+    pub fn contains(&self, path: impl AsRef<str>) -> Result<Option<File>> {
+        let path = CString::new(path.as_ref()).unwrap();
         let file = unsafe {
             alpm_filelist_contains(
                 &self.inner as *const alpm_filelist_t as *mut alpm_filelist_t,

--- a/alpm/src/handle.rs
+++ b/alpm/src/handle.rs
@@ -89,13 +89,13 @@ impl Alpm {
         unsafe { from_cstr(alpm_option_get_dbext(self.handle)) }
     }
 
-    pub fn add_hookdir<S: Into<String>>(&mut self, s: S) -> Result<()> {
-        let s = CString::new(s.into()).unwrap();
+    pub fn add_hookdir(&mut self, s: impl AsRef<str>) -> Result<()> {
+        let s = CString::new(s.as_ref()).unwrap();
         let ret = unsafe { alpm_option_add_hookdir(self.handle, s.as_ptr()) };
         self.check_ret(ret)
     }
 
-    pub fn set_hookdirs<S: Into<String>, I: IntoIterator<Item = S>>(
+    pub fn set_hookdirs<S: AsRef<str>, I: IntoIterator<Item = S>>(
         &mut self,
         list: I,
     ) -> Result<()> {
@@ -106,8 +106,8 @@ impl Alpm {
         self.check_ret(ret)
     }
 
-    pub fn remove_hookdir<S: Into<String>>(&mut self, s: S) -> Result<bool> {
-        let s = CString::new(s.into()).unwrap();
+    pub fn remove_hookdir(&mut self, s: impl AsRef<str>) -> Result<bool> {
+        let s = CString::new(s.as_ref()).unwrap();
         let ret = unsafe { alpm_option_remove_hookdir(self.handle, s.as_ptr()) };
         if ret == 1 {
             Ok(true)
@@ -116,13 +116,13 @@ impl Alpm {
         }
     }
 
-    pub fn add_cachedir<S: Into<String>>(&mut self, s: S) -> Result<()> {
-        let s = CString::new(s.into()).unwrap();
+    pub fn add_cachedir(&mut self, s: impl AsRef<str>) -> Result<()> {
+        let s = CString::new(s.as_ref()).unwrap();
         let ret = unsafe { alpm_option_add_cachedir(self.handle, s.as_ptr()) };
         self.check_ret(ret)
     }
 
-    pub fn set_cachedirs<S: Into<String>, I: IntoIterator<Item = S>>(
+    pub fn set_cachedirs<S: AsRef<str>, I: IntoIterator<Item = S>>(
         &mut self,
         list: I,
     ) -> Result<()> {
@@ -133,8 +133,8 @@ impl Alpm {
         self.check_ret(ret)
     }
 
-    pub fn remove_cachedir<S: Into<String>>(&mut self, s: S) -> Result<bool> {
-        let s = CString::new(s.into()).unwrap();
+    pub fn remove_cachedir(&mut self, s: impl AsRef<str>) -> Result<bool> {
+        let s = CString::new(s.as_ref()).unwrap();
         let ret = unsafe { alpm_option_remove_cachedir(self.handle, s.as_ptr()) };
         if ret == 1 {
             Ok(true)
@@ -143,14 +143,14 @@ impl Alpm {
         }
     }
 
-    pub fn set_logfile<S: Into<String>>(&self, s: S) -> Result<()> {
-        let s = CString::new(s.into()).unwrap();
+    pub fn set_logfile(&self, s: impl AsRef<str>) -> Result<()> {
+        let s = CString::new(s.as_ref()).unwrap();
         let ret = unsafe { alpm_option_set_logfile(self.handle, s.as_ptr()) };
         self.check_ret(ret)
     }
 
-    pub fn set_gpgdir<S: Into<String>>(&self, s: S) -> Result<()> {
-        let s = CString::new(s.into()).unwrap();
+    pub fn set_gpgdir(&self, s: impl AsRef<str>) -> Result<()> {
+        let s = CString::new(s.as_ref()).unwrap();
         let ret = unsafe { alpm_option_set_gpgdir(self.handle, s.as_ptr()) };
         self.check_ret(ret)
     }
@@ -160,13 +160,13 @@ impl Alpm {
         unsafe { alpm_option_set_usesyslog(self.handle, b) };
     }
 
-    pub fn add_noupgrade<S: Into<String>>(&mut self, s: S) -> Result<()> {
-        let s = CString::new(s.into()).unwrap();
+    pub fn add_noupgrade(&mut self, s: impl AsRef<str>) -> Result<()> {
+        let s = CString::new(s.as_ref()).unwrap();
         let ret = unsafe { alpm_option_add_noupgrade(self.handle, s.as_ptr()) };
         self.check_ret(ret)
     }
 
-    pub fn set_noupgrades<S: Into<String>, I: IntoIterator<Item = S>>(
+    pub fn set_noupgrades<S: AsRef<str>, I: IntoIterator<Item = S>>(
         &mut self,
         list: I,
     ) -> Result<()> {
@@ -177,8 +177,8 @@ impl Alpm {
         self.check_ret(ret)
     }
 
-    pub fn remove_noupgrade<S: Into<String>>(&mut self, s: S) -> Result<bool> {
-        let s = CString::new(s.into()).unwrap();
+    pub fn remove_noupgrade(&mut self, s: impl AsRef<str>) -> Result<bool> {
+        let s = CString::new(s.as_ref()).unwrap();
         let ret = unsafe { alpm_option_remove_noupgrade(self.handle, s.as_ptr()) };
         if ret == 1 {
             Ok(true)
@@ -187,8 +187,8 @@ impl Alpm {
         }
     }
 
-    pub fn match_noupgrade<S: Into<String>>(&mut self, s: S) -> Match {
-        let s = CString::new(s.into()).unwrap();
+    pub fn match_noupgrade(&mut self, s: impl AsRef<str>) -> Match {
+        let s = CString::new(s.as_ref()).unwrap();
         let ret = unsafe { alpm_option_match_noupgrade(self.handle, s.as_ptr()) };
 
         match ret.cmp(&0) {
@@ -198,13 +198,13 @@ impl Alpm {
         }
     }
 
-    pub fn add_noextract<S: Into<String>>(&mut self, s: S) -> Result<()> {
-        let s = CString::new(s.into()).unwrap();
+    pub fn add_noextract(&mut self, s: impl AsRef<str>) -> Result<()> {
+        let s = CString::new(s.as_ref()).unwrap();
         let ret = unsafe { alpm_option_add_noextract(self.handle, s.as_ptr()) };
         self.check_ret(ret)
     }
 
-    pub fn set_noextracts<S: Into<String>, I: IntoIterator<Item = S>>(
+    pub fn set_noextracts<S: AsRef<str>, I: IntoIterator<Item = S>>(
         &mut self,
         list: I,
     ) -> Result<()> {
@@ -215,8 +215,8 @@ impl Alpm {
         self.check_ret(ret)
     }
 
-    pub fn remove_noextract<S: Into<String>>(&mut self, s: S) -> Result<bool> {
-        let s = CString::new(s.into()).unwrap();
+    pub fn remove_noextract(&mut self, s: impl AsRef<str>) -> Result<bool> {
+        let s = CString::new(s.as_ref()).unwrap();
         let ret = unsafe { alpm_option_remove_noextract(self.handle, s.as_ptr()) };
         if ret == 1 {
             Ok(true)
@@ -225,8 +225,8 @@ impl Alpm {
         }
     }
 
-    pub fn match_noextract<S: Into<String>>(&mut self, s: S) -> Match {
-        let s = CString::new(s.into()).unwrap();
+    pub fn match_noextract(&mut self, s: impl AsRef<str>) -> Match {
+        let s = CString::new(s.as_ref()).unwrap();
         let ret = unsafe { alpm_option_match_noextract(self.handle, s.as_ptr()) };
 
         match ret.cmp(&0) {
@@ -236,13 +236,13 @@ impl Alpm {
         }
     }
 
-    pub fn add_ignorepkg<S: Into<String>>(&mut self, s: S) -> Result<()> {
-        let s = CString::new(s.into()).unwrap();
+    pub fn add_ignorepkg(&mut self, s: impl AsRef<str>) -> Result<()> {
+        let s = CString::new(s.as_ref()).unwrap();
         let ret = unsafe { alpm_option_add_ignorepkg(self.handle, s.as_ptr()) };
         self.check_ret(ret)
     }
 
-    pub fn set_ignorepkgs<S: Into<String>, I: IntoIterator<Item = S>>(
+    pub fn set_ignorepkgs<S: AsRef<str>, I: IntoIterator<Item = S>>(
         &mut self,
         list: I,
     ) -> Result<()> {
@@ -253,8 +253,8 @@ impl Alpm {
         self.check_ret(ret)
     }
 
-    pub fn remove_ignorepkg<S: Into<String>>(&mut self, s: S) -> Result<bool> {
-        let s = CString::new(s.into()).unwrap();
+    pub fn remove_ignorepkg(&mut self, s: impl AsRef<str>) -> Result<bool> {
+        let s = CString::new(s.as_ref()).unwrap();
         let ret = unsafe { alpm_option_remove_ignorepkg(self.handle, s.as_ptr()) };
         if ret == 1 {
             Ok(true)
@@ -263,13 +263,13 @@ impl Alpm {
         }
     }
 
-    pub fn add_ignoregroup<S: Into<String>>(&mut self, s: S) -> Result<()> {
-        let s = CString::new(s.into()).unwrap();
+    pub fn add_ignoregroup(&mut self, s: impl AsRef<str>) -> Result<()> {
+        let s = CString::new(s.as_ref()).unwrap();
         let ret = unsafe { alpm_option_add_ignoregroup(self.handle, s.as_ptr()) };
         self.check_ret(ret)
     }
 
-    pub fn set_ignoregroups<S: Into<String>, I: IntoIterator<Item = S>>(
+    pub fn set_ignoregroups<S: AsRef<str>, I: IntoIterator<Item = S>>(
         &mut self,
         list: I,
     ) -> Result<()> {
@@ -280,8 +280,8 @@ impl Alpm {
         self.check_ret(ret)
     }
 
-    pub fn remove_ignoregroup<S: Into<String>>(&mut self, s: S) -> Result<bool> {
-        let s = CString::new(s.into()).unwrap();
+    pub fn remove_ignoregroup(&mut self, s: impl AsRef<str>) -> Result<bool> {
+        let s = CString::new(s.as_ref()).unwrap();
         let ret = unsafe { alpm_option_remove_ignoregroup(self.handle, s.as_ptr()) };
         if ret == 1 {
             Ok(true)
@@ -290,13 +290,13 @@ impl Alpm {
         }
     }
 
-    pub fn add_overwrite_file<S: Into<String>>(&mut self, s: S) -> Result<()> {
-        let s = CString::new(s.into()).unwrap();
+    pub fn add_overwrite_file(&mut self, s: impl AsRef<str>) -> Result<()> {
+        let s = CString::new(s.as_ref()).unwrap();
         let ret = unsafe { alpm_option_add_overwrite_file(self.handle, s.as_ptr()) };
         self.check_ret(ret)
     }
 
-    pub fn set_overwrite_files<S: Into<String>, I: IntoIterator<Item = S>>(
+    pub fn set_overwrite_files<S: AsRef<str>, I: IntoIterator<Item = S>>(
         &mut self,
         list: I,
     ) -> Result<()> {
@@ -307,8 +307,8 @@ impl Alpm {
         self.check_ret(ret)
     }
 
-    pub fn remove_overwrite_file<S: Into<String>>(&mut self, s: S) -> Result<bool> {
-        let s = CString::new(s.into()).unwrap();
+    pub fn remove_overwrite_file(&mut self, s: impl AsRef<str>) -> Result<bool> {
+        let s = CString::new(s.as_ref()).unwrap();
         let ret = unsafe { alpm_option_remove_overwrite_file(self.handle, s.as_ptr()) };
         if ret == 1 {
             Ok(true)
@@ -349,8 +349,8 @@ impl Alpm {
         }
     }
 
-    pub fn set_arch<S: Into<String>>(&self, s: S) {
-        let s = CString::new(s.into()).unwrap();
+    pub fn set_arch(&self, s: impl AsRef<str>) {
+        let s = CString::new(s.as_ref()).unwrap();
         unsafe { alpm_option_set_arch(self.handle, s.as_ptr()) };
     }
 
@@ -374,8 +374,8 @@ impl Alpm {
         unsafe { alpm_option_set_checkspace(self.handle, b) };
     }
 
-    pub fn set_dbext<S: Into<String>>(&self, s: S) {
-        let s = CString::new(s.into()).unwrap();
+    pub fn set_dbext(&self, s: impl AsRef<str>) {
+        let s = CString::new(s.as_ref()).unwrap();
         unsafe { alpm_option_set_dbext(self.handle, s.as_ptr()) };
     }
 

--- a/alpm/src/signing.rs
+++ b/alpm/src/signing.rs
@@ -9,8 +9,8 @@ use std::ffi::{c_void, CString};
 use std::mem::transmute;
 use std::{ptr, slice};
 
-pub fn decode_signature<S: Into<String>>(b64: S) -> std::result::Result<Vec<u8>, ()> {
-    let b64 = CString::new(b64.into()).unwrap();
+pub fn decode_signature(b64: impl AsRef<str>) -> std::result::Result<Vec<u8>, ()> {
+    let b64 = CString::new(b64.as_ref()).unwrap();
     let mut data = ptr::null_mut();
     let mut len = 0;
     let ret = unsafe { alpm_decode_signature(b64.as_ptr(), &mut data, &mut len) };
@@ -172,12 +172,12 @@ impl<'a> Db<'a> {
 }
 
 impl Alpm {
-    pub fn extract_keyid<'a, S: Into<String>>(
+    pub fn extract_keyid<'a>(
         &'a self,
-        ident: S,
+        ident: impl AsRef<str>,
         sig: &[u8],
     ) -> Result<AlpmList<'a, String>> {
-        let ident = CString::new(ident.into()).unwrap();
+        let ident = CString::new(ident.as_ref()).unwrap();
         let mut keys = ptr::null_mut();
 
         let ret = unsafe {

--- a/alpm/src/sync.rs
+++ b/alpm/src/sync.rs
@@ -22,12 +22,12 @@ impl<'a> Package<'a> {
 }
 
 impl Alpm {
-    pub fn find_group_pkgs<'a, S: Into<String>>(
+    pub fn find_group_pkgs<'a>(
         &'a self,
         dbs: AlpmList<Db>,
-        s: S,
+        s: impl AsRef<str>,
     ) -> AlpmList<'a, Package<'a>> {
-        let name = CString::new(s.into()).unwrap();
+        let name = CString::new(s.as_ref()).unwrap();
         let ret = unsafe { alpm_find_group_pkgs(dbs.list, name.as_ptr()) };
         AlpmList::new(self, ret, FreeMethod::FreeList)
     }

--- a/alpm/src/util.rs
+++ b/alpm/src/util.rs
@@ -2,8 +2,8 @@ use std::ffi::{CStr, CString};
 
 use alpm_sys::*;
 
-pub fn compute_md5sum<S: Into<String>>(s: S) -> Result<String, ()> {
-    let s = CString::new(s.into()).unwrap();
+pub fn compute_md5sum(s: impl AsRef<str>) -> Result<String, ()> {
+    let s = CString::new(s.as_ref()).unwrap();
     let ret = unsafe { alpm_compute_md5sum(s.as_ptr()) };
     if ret.is_null() {
         return Err(());
@@ -13,8 +13,8 @@ pub fn compute_md5sum<S: Into<String>>(s: S) -> Result<String, ()> {
     Ok(s.into())
 }
 
-pub fn compute_sha256sum<S: Into<String>>(s: S) -> Result<String, ()> {
-    let s = CString::new(s.into()).unwrap();
+pub fn compute_sha256sum(s: impl AsRef<str>) -> Result<String, ()> {
+    let s = CString::new(s.as_ref()).unwrap();
     let ret = unsafe { alpm_compute_sha256sum(s.as_ptr()) };
     if ret.is_null() {
         return Err(());

--- a/alpm/src/utils.rs
+++ b/alpm/src/utils.rs
@@ -19,11 +19,11 @@ pub unsafe fn from_cstr_optional<'a>(s: *const c_char) -> Option<&'a str> {
         .filter(|s| !s.is_empty())
 }
 
-pub fn to_strlist<S: Into<String>, I: IntoIterator<Item = S>>(list: I) -> *mut alpm_list_t {
+pub fn to_strlist<S: AsRef<str>, I: IntoIterator<Item = S>>(list: I) -> *mut alpm_list_t {
     let mut alpmlist = ptr::null_mut();
 
     for s in list {
-        let cs = CString::new(s.into()).unwrap();
+        let cs = CString::new(s.as_ref()).unwrap();
         unsafe { alpm_list_append_strdup(&mut alpmlist, cs.as_ptr()) };
     }
 

--- a/alpm/src/version.rs
+++ b/alpm/src/version.rs
@@ -7,9 +7,9 @@ use std::os::raw::c_char;
 
 use alpm_sys::*;
 
-pub fn vercmp<S: Into<String>>(a: S, b: S) -> Ordering {
-    let a = CString::new(a.into()).unwrap();
-    let b = CString::new(b.into()).unwrap();
+pub fn vercmp(a: impl AsRef<str>, b: impl AsRef<str>) -> Ordering {
+    let a = CString::new(a.as_ref()).unwrap();
+    let b = CString::new(b.as_ref()).unwrap();
     unsafe { alpm_pkg_vercmp(a.as_ptr(), b.as_ptr()).cmp(&0) }
 }
 
@@ -92,8 +92,8 @@ impl PartialOrd<Version> for &Ver {
 pub struct Version(CString);
 
 impl Version {
-    pub fn new<S: Into<String>>(s: S) -> Self {
-        let s = CString::new(s.into()).unwrap();
+    pub fn new(s: impl AsRef<str>) -> Self {
+        let s = CString::new(s.as_ref()).unwrap();
         Version(s)
     }
 


### PR DESCRIPTION
Basically just replaces a bunch of `Into<String>` with `AsRef<str>`.