### PR TITLE
Make Alpm be Send

### DIFF
--- a/alpm/src/alpm.rs
+++ b/alpm/src/alpm.rs
@@ -26,6 +26,8 @@ pub struct Alpm {
     pub(crate) drop: bool,
 }
 
+unsafe impl Send for Alpm {}
+
 impl Drop for Alpm {
     fn drop(&mut self) {
         if self.drop {


### PR DESCRIPTION
Note: I've only used Rust for a few days, so this might not make Alpm be Send.