### PR TITLE
fix: Segfault in db.groups

### DIFF
--- a/alpm/src/db.rs
+++ b/alpm/src/db.rs
@@ -164,7 +164,7 @@ impl<'a> Db<'a> {
     }
 
     pub fn groups(&self) -> Result<AlpmList<'a, Group>> {
-        let groups = unsafe { alpm_db_get_pkgcache(self.db) };
+        let groups = unsafe { alpm_db_get_groupcache(self.db) };
         self.handle.check_null(groups)?;
         Ok(AlpmList::new(self.handle, groups, FreeMethod::FreeList))
     }


### PR DESCRIPTION
The `groups` function on a database incorrectly called `alpm_db_get_pkgcache` while it should have called `alpm_db_get_groupcache` which caused a Segfault. This should fix it.