### PR TITLE
Added "repo" and "repository" alias for Db

### DIFF
--- a/alpm/src/db.rs
+++ b/alpm/src/db.rs
@@ -10,6 +10,7 @@ use std::ops::Deref;
 use alpm_sys::*;
 
 #[derive(Copy, Clone)]
+#[doc(alias("repo", "repository"))]
 pub struct Db<'a> {
     pub(crate) db: *mut alpm_db_t,
     pub(crate) handle: &'a Alpm,


### PR DESCRIPTION
Added "repo" and "repository" alias for Db struct in db.rs
should make the relation a bit clearer 