### PR TITLE
feat: use new sandbox fields from pacmanconf for git feature

### DIFF
--- a/alpm-utils/src/conf.rs
+++ b/alpm-utils/src/conf.rs
@@ -59,8 +59,10 @@ pub fn configure_alpm(alpm: &mut Alpm, conf: &Config) -> alpm::Result<()> {
     alpm.set_parallel_downloads(conf.parallel_downloads as u32);
     #[cfg(feature = "git")]
     {
-        alpm.set_disable_sandbox_filesystem(conf.disable_sandbox);
-        alpm.set_disable_sandbox_syscalls(conf.disable_sandbox);
+        alpm.set_disable_sandbox_filesystem(
+            conf.disable_sandbox_filesystem || conf.disable_sandbox,
+        );
+        alpm.set_disable_sandbox_syscalls(conf.disable_sandbox_syscalls || conf.disable_sandbox);
     }
     #[cfg(not(feature = "git"))]
     alpm.set_disable_sandbox(conf.disable_sandbox);


### PR DESCRIPTION
Update alpm-utils to use the new disable_sandbox_filesystem and disable_sandbox_syscalls fields from pacmanconf when the git feature is enabled, instead of using the legacy disable_sandbox field for both.