### PR TITLE
4.x branch - Fix alpm-sys build.rs version check

### DIFF
--- a/alpm-sys/build.rs
+++ b/alpm-sys/build.rs
@@ -27,10 +27,10 @@ fn main() {
     println!("cargo::metadata=libalpm_version={}", lib.version);
 
     println!("cargo::rustc-check-cfg=cfg(alpm15,alpm16)");
-    if lib.version == "15.0.0" {
+    if lib.version.starts_with("15.") {
         println!("cargo::rustc-cfg=alpm15");
     }
-    if lib.version == "16.0.0" || cfg!(feature = "git") {
+    if lib.version.starts_with("16.") || cfg!(feature = "git") {
         println!("cargo::rustc-cfg=alpm15");
         println!("cargo::rustc-cfg=alpm16");
     }


### PR DESCRIPTION
The version checks in the `build.rs` file for the alpm crate and the alpm-sys crate are different, the alpm crate only checks for the major version, alpm-sys checks that the version matches `16.0.0` exactly.  
At time of writing the libalpm.so version is `16.0.1`, leading to the alpm16 cfg flag being set for alpm, but not alpm-sys causing the build to fail.

This pull-request fixes this issue by reusing the comparison logic from alpm in alpm-sys. I chose to loosen the check in alpm-sys because the cfg flag also only specifies the major version.  
An alternative would be to check for each supported version, in case a future minor version upgrade breaks something, however then there should be an explicit error when an unknown version is encountered (instead of the current situation where the alpm16 flag is enabled for one create, but disabled for the other).