### PR TITLE
feat: Add trans_add_pkg_by_name and trans_remove_pkg_by_name

### DIFF
--- a/alpm/src/remove.rs
+++ b/alpm/src/remove.rs
@@ -1,3 +1,5 @@
+use std::ffi::CString;
+
 use crate::{Alpm, Package, Result};
 
 use alpm_sys::*;
@@ -5,6 +7,36 @@ use alpm_sys::*;
 impl Alpm {
     pub fn trans_remove_pkg(&self, pkg: &Package) -> Result<()> {
         let ret = unsafe { alpm_remove_pkg(self.as_ptr(), pkg.as_ptr()) };
+        self.check_ret(ret)
+    }
+
+    /// Remove a package from the transaction by name.
+    ///
+    /// This is a convenience method that looks up the package in the local database
+    /// and adds it to the removal transaction. It avoids borrow checker conflicts
+    /// that occur when holding `&Package` references across transaction operations
+    /// like `trans_prepare()`.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use alpm::{Alpm, TransFlag};
+    ///
+    /// let mut handle = Alpm::new("/", "/var/lib/pacman").unwrap();
+    /// let names = ["package1", "package2"];
+    ///
+    /// handle.trans_init(TransFlag::empty()).unwrap();
+    /// for name in names {
+    ///     handle.trans_remove_pkg_by_name(name).unwrap();
+    /// }
+    /// handle.trans_prepare().unwrap();
+    /// handle.trans_commit().unwrap();
+    /// handle.trans_release().unwrap();
+    /// ```
+    pub fn trans_remove_pkg_by_name<S: Into<Vec<u8>>>(&self, name: S) -> Result<()> {
+        let name = CString::new(name).unwrap();
+        let pkg = unsafe { alpm_db_get_pkg(alpm_get_localdb(self.as_ptr()), name.as_ptr()) };
+        self.check_null(pkg)?;
+        let ret = unsafe { alpm_remove_pkg(self.as_ptr(), pkg) };
         self.check_ret(ret)
     }
 }


### PR DESCRIPTION
These convenience methods perform database lookups internally, avoiding borrow checker conflicts when holding `&Package` references across transaction operations like `trans_prepare()`.
`trans_remove_pkg_by_name` looks up package in localdb; `trans_add_pkg_by_name` searches all registered sync databases.

For extra context, I was working on adding orphan cleanup features to cockpit-pacman and notice that when removing packages, the typical pattern hits a borrow checker conflict like e.g.:

```rust
let orphans: Vec<&Package> = handle.localdb().pkgs()
    .iter()
    .filter(|p| /* ... */)
    .collect();

handle.trans_init(TransFlag::empty())?;
for pkg in &orphans {
    handle.trans_remove_pkg(*pkg)?;
}
handle.trans_prepare()?;  // ERROR: cannot borrow handle mutably
```

The `&Package` references borrow from the handle, preventing `trans_prepare(&mut self)`. Users must work around this by collecting package names as owned strings first.

These new methods encapsulate the lookup, so no `&Package` escapes:

```rust
let names: Vec<String> = orphans.iter().map(|p| p.name().to_string()).collect();

handle.trans_init(TransFlag::empty())?;
for name in &names {
    handle.trans_remove_pkg_by_name(name.as_str())?;
}
handle.trans_prepare()?;  // Works
```

I thought it would make sense to upstream this, maybe. Looking forward to hearing your thoughts.