### PR TITLE
ci: detect drift between committed and generated FFI bindings

### DIFF
--- a/.github/workflows/alpm.yml
+++ b/.github/workflows/alpm.yml
@@ -14,7 +14,7 @@ jobs:
       image: archlinux
     steps:
       - name: Install Packages
-        run: pacman -Syu rust clang gcc libarchive pkgconf --noconfirm --needed
+        run: pacman -Syu rust clang gcc libarchive pkgconf diffutils --noconfirm --needed
 
       - name: Checkout
         uses: actions/checkout@v2
@@ -26,6 +26,12 @@ jobs:
       - name: Test
         run: cargo test --features generate,mtree
         working-directory: alpm
+
+      - name: Check committed bindings are up to date
+        run: |
+          generated=$(find target -name ffi_generated.rs -path '*/alpm-sys-*/out/*' | head -1)
+          if [ -z "$generated" ]; then echo "ffi_generated.rs not found"; exit 1; fi
+          diff -u alpm-sys/src/ffi.rs "$generated"
 
   test-git:
     runs-on: ubuntu-latest
@@ -54,3 +60,9 @@ jobs:
       - name: Test
         run: cargo test --features generate,git,mtree
         working-directory: alpm
+
+      - name: Check committed git bindings are up to date
+        run: |
+          generated=$(find target -name ffi_generated.rs -path '*/alpm-sys-*/out/*' | head -1)
+          if [ -z "$generated" ]; then echo "ffi_generated.rs not found"; exit 1; fi
+          diff -u alpm-sys/src/ffi_git.rs "$generated"


### PR DESCRIPTION
The pre-generated ffi.rs and ffi_git.rs files can silently diverge from what bindgen produces if someone updates libalpm headers without regenerating. Add a diff check after the test step in both CI jobs to catch this.

Related: https://github.com/archlinux/alpm.rs/pull/67